### PR TITLE
Perbaikan Bug

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -284,29 +284,19 @@ const Controller = function(router) {
       }
     })
 
-    fsx
-      .remove(filepath)
-      .then(() => {
-        return help.sendBackJSON(
-          200,
-          {
-            status: true,
-            message: 'File has been deleted successfully.'
-          },
-          res
-        )
-      })
-      .catch(err => {
-        return help.sendBackJSON(
-          500,
-          {
-            status: false,
-            message: `Unable to delete file ${filename}`,
-            debug: err
-          },
-          res
-        )
-      })
+    fsx.remove(filepath, function (err) {
+      if (err) {
+        return help.sendBackJSON(500, {
+          status: false,
+          message: `Unable to delete file ${filename}`,
+          debug: err
+        }, res)
+      }
+      return help.sendBackJSON(200, {
+        status: true,
+        message: 'File has been deleted successfully.'
+      }, res)
+    })
   })
 
   router.delete('/delete_asset', (req, res) => {
@@ -359,29 +349,19 @@ const Controller = function(router) {
       }
     })
 
-    fsx
-      .remove(filepath)
-      .then(() => {
-        return help.sendBackJSON(
-          200,
-          {
-            status: true,
-            message: 'File has been deleted successfully.'
-          },
-          res
-        )
-      })
-      .catch(err => {
-        return help.sendBackJSON(
-          500,
-          {
-            status: false,
-            message: `Unable to delete file ${filename}`,
-            debug: err
-          },
-          res
-        )
-      })
+    fsx.remove(filepath, function (err) {
+      if (err) {
+        return help.sendBackJSON(500, {
+          status: false,
+          message: `Unable to delete file ${filename}`,
+          debug: err
+        }, res)
+      }
+      return help.sendBackJSON(200, {
+        status: true,
+        message: 'File has been deleted successfully.'
+      }, res)
+    })
   })
 
   router.get('/robots.txt', (req, res) => {


### PR DESCRIPTION
Perubahan ini akan memperbaiki error berikut:
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:405:5)
    at ServerResponse.setHeader (node:_http_outgoing:652:11)
    at ServerResponse.header (/tmp/async/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/response.js:794:10)
    at ServerResponse.send (/tmp/async/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/response.js:174:12)
    at /tmp/async/index.js:29:9
    at Timeout._onTimeout (/tmp/async/index.js:15:5)
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```

yang dimana artinya express sudah memberikan response kepada client namun program kita masih memproses dalam hal ini mengatur header.

Masalah ini sudah diatasi dengan `async await` supaya express handler menunggu proses kita yang sedang berjalan sampai beres, sebelum mengirimkan ke client.

    Catatan:
    Beberapa perubahan tambahan code standard yang sudah ditentukan oleh dadi cdn menggunakan eslint.